### PR TITLE
add stream.socket to incoming requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,9 @@ exports.createServer = function (onConnection) {
     proxy(server, 'close')
 
     wsServer.on('connection', function (socket) {
-      emitter.emit('connection', ws(socket))
+      var stream = ws(socket)
+      stream.socket = socket
+      emitter.emit('connection', stream)
     })
 
     if(onListening)


### PR DESCRIPTION
This matches the pull-stream emitted for incoming connections to the pull-stream returned by `.connect()`. Enables the server to read metadata about the connection, such as the remote address.