### PR TITLE
replace stream.socket with selective event-options and stream attributes

### DIFF
--- a/client.js
+++ b/client.js
@@ -18,11 +18,11 @@ exports.connect = function (addr, opts) {
   var stream = ws(socket)
   stream.remoteAddress = u
 
-  if (opts && typeof opts.onopen == 'function') {
-    socket.on('open', opts.onopen)
+  if (opts && typeof opts.onOpen == 'function') {
+    socket.on('open', opts.onOpen)
   }
-  if (opts && typeof opts.onclose == 'function') {
-    socket.on('close', opts.onclose)
+  if (opts && typeof opts.onClose == 'function') {
+    socket.on('close', opts.onClose)
   }
 
   return stream

--- a/client.js
+++ b/client.js
@@ -2,7 +2,7 @@ var ws = require('pull-ws')
 var WebSocket = require('ws')
 var url = require('url')
 
-exports.connect = function (addr, cb) {
+exports.connect = function (addr, opts) {
   var u = (
     'string' === typeof addr
   ? addr
@@ -16,7 +16,15 @@ exports.connect = function (addr, cb) {
 
   var socket = new WebSocket(u)
   var stream = ws(socket)
-  stream.socket = socket
+  stream.remoteAddress = u
+
+  if (opts && typeof opts.onopen == 'function') {
+    socket.on('open', opts.onopen)
+  }
+  if (opts && typeof opts.onclose == 'function') {
+    socket.on('close', opts.onclose)
+  }
+
   return stream
 }
 

--- a/index.js
+++ b/index.js
@@ -29,7 +29,9 @@ exports.createServer = function (onConnection) {
     proxy(server, 'close')
 
     wsServer.on('connection', function (socket) {
-      emitter.emit('connection', ws(socket))
+      var stream = ws(socket)
+      stream.remoteAddress = socket.upgradeReq.socket.remoteAddress
+      emitter.emit('connection', stream)
     })
 
     if(onListening)


### PR DESCRIPTION
removes the websocket object from `stream.socket` and replaces it with options to set connection open/close events, plus a `remoteAddress` attribute for consuming libraries to read