### PR TITLE
Add optional host argument to listen

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,10 +23,15 @@ exports.createServer = function (onConnection) {
   var server = http.createServer()
   var wsServer = new WebSocket.Server({server: server})
 
-  emitter.listen = function (addr, onListening) {
+  emitter.listen = function (addr, host, onListening) {
     proxy(server, 'listening')
     proxy(server, 'request')
     proxy(server, 'close')
+
+    if(typeof host == 'function') {
+      onListening = host
+      host = null
+    }
 
     wsServer.on('connection', function (socket) {
       var stream = ws(socket)
@@ -36,7 +41,7 @@ exports.createServer = function (onConnection) {
 
     if(onListening)
       emitter.once('listening', onListening)
-    server.listen(addr.port || addr)
+    server.listen(addr.port || addr, host || '0.0.0.0')
     return emitter
   }
 


### PR DESCRIPTION
This allows passing a host argument to `server.listen`, as in [net.Server.prototype.listen](https://nodejs.org/docs/latest/api/net.html#net_server_listen_port_host_backlog_callback). Existing behavior of defaulting to 0.0.0.0 (INADDR_ANY) is preserved.