### PR TITLE
Declare `called` variable

### DIFF
--- a/client.js
+++ b/client.js
@@ -10,6 +10,7 @@ function isFunction (f) {
 exports.connect = function (addr, opts) {
   if(isFunction(opts)) {
     var cb = opts
+    var called = false
     opts = {
       onOpen: function () {
         if(called) return


### PR DESCRIPTION
This fixes the following error:
```
/usr/local/src/pull-ws-server/client.js:15
        if(called) return
           ^
ReferenceError: called is not defined
    at WebSocket.opts.onOpen (/usr/local/src/pull-ws-server/client.js:15:12)
    at WebSocket.emit (events.js:117:20)
    at WebSocket.establishConnection (/usr/local/src/pull-ws-server/node_modules/ws/lib/WebSocket.js:786:8)
    at ClientRequest.upgrade (/usr/local/src/pull-ws-server/node_modules/ws/lib/WebSocket.js:677:25)
    at ClientRequest.g (events.js:180:16)
    at ClientRequest.emit (events.js:106:17)
    at Socket.socketOnData (http.js:1612:11)
    at TCP.onread (net.js:527:27)

```